### PR TITLE
[ELO Url fix]

### DIFF
--- a/src/playersElo.js
+++ b/src/playersElo.js
@@ -1,6 +1,6 @@
 import { getPersonalScoreboard } from "./scoreboard";
 
-let url = "https://haxrecordings.s3.amazonaws.com/scoarboard.json";
+let url = "https://haxrecordings.s3.amazonaws.com/scoreboard.json";
 
 let playersElo = async function () {
   const result = await fetch(url)


### PR DESCRIPTION
Estaba la URL mal, pero nunca me di cuenta porque siempre copiaba el **contenido del chat** de haxball.

Cuando hice el arreglo para que **descargara** el archivo en vez de tirarlo en el chat (porque se saturaba el buffer del chat),  ahi descargue el archivo con el nombre correcto. Entonces en S3 subia el archivo que nunca se tomo en cuenta :f: 😢 