### PR TITLE
[ELO change] k = 15

### DIFF
--- a/src/eloCalculation.js
+++ b/src/eloCalculation.js
@@ -14,7 +14,7 @@ function totalTeamElo(players, personalScoreboard) {
 }
 
 function newEloDelta(totalTeamElo, hasWon, totalOpponentTeamElo) {
-  const k = 30;
+  const k = 15;
   const finalScore = (hasWon ? 1 : 0);
   const expectedScore = 1 / (1 + 10**((totalOpponentTeamElo - totalTeamElo) / 400));
 

--- a/tests/eloCalculation.test.js
+++ b/tests/eloCalculation.test.js
@@ -36,13 +36,13 @@ const personalScoreboardCopy = {
 describe('calculateNewEloDelta', () => {
   describe('when the team has won', () => {
     it('returns positive points variation for the teamA that has won', () => {
-      expect(calculateNewEloDelta(teamA, true, teamB, personalScoreboardCopy)).toBe(9);
+      expect(calculateNewEloDelta(teamA, true, teamB, personalScoreboardCopy)).toBe(5);
     });
   });
 
   describe('when the team has lost', () => {
     it('returns negative points variation for the teamA that has lost', () => {
-      expect(calculateNewEloDelta(teamA, false, teamB, personalScoreboardCopy)).toBe(-21);
+      expect(calculateNewEloDelta(teamA, false, teamB, personalScoreboardCopy)).toBe(-10);
     });
   });
 });


### PR DESCRIPTION
Changing this to see less disruptive changes on the ELO rating.

Now the most points that you can get are **15** and the least points that you can lose are **-15**.

In this match https://haxlaton.dokku.1ma.dev/matches/230 **Kevo** and **El Bicho** would lost only 10 points, instead of 21 (19 was wrongly calculated because of a bug)